### PR TITLE
Fixed the recently used item timing and added simple print feature

### DIFF
--- a/cache/Cache.py
+++ b/cache/Cache.py
@@ -49,7 +49,7 @@ class Cache:
         # add a variable to hold a counter used for the last recently used entry (used only for cache types that need it)
         self._last_recently_used_counter = 0;
 
-    def cache(self, address):
+    def cache(self, address, allow_print):
         """
         :param address: the address in hex decimal of type stirng
         :return: nothing
@@ -61,6 +61,8 @@ class Cache:
         if self._byte_addressed:
             base -= 2
 
+        # the word index bit (currently only used for printing purposes)
+        word_index_bit = binary_address[base - self._word_index_size: base]
         # Get a list of words contains all words in block with the right word index for each
         words = self._completeBlock(binary_address, base - self._word_index_size, base)
         base -= self._word_index_size
@@ -73,11 +75,17 @@ class Cache:
         # After the index assign the rest of the bits to tag
         tag = binary_address[:base]
 
+        #printing capture variable
+        print_status = "Miss"
         if self.isHit(binary_address, index):
             self._hits += 1
+            print_status = "Hit "
         else:
             self._misses += 1
             self._addToCache(index, tag, words)
+
+        if allow_print:
+            print "%s : %s [index: %s, tag: %s, word_index: %s]" %(address, print_status, bin(index)[2:].zfill(self._index_size), tag,  word_index_bit)
 
     @abc.abstractmethod
     def isHit(self, address, index):

--- a/cache/Cache.py
+++ b/cache/Cache.py
@@ -46,6 +46,9 @@ class Cache:
         self._hits = 0
         self._misses = 0
 
+        # add a variable to hold a counter used for the last recently used entry (used only for cache types that need it)
+        self._last_recently_used_counter = 0;
+
     def cache(self, address):
         """
         :param address: the address in hex decimal of type stirng
@@ -140,3 +143,13 @@ class Cache:
             currentAddress[startIndex: endIndex] = bin(i)[2:].zfill(size)
             words += [''.join(currentAddress)]
         return words
+
+
+    def _generateRecentlyUsedCode(self):
+        """
+        Get a higher recently used code and update the recently used counter.
+        :return: number
+        """
+        tmp = self._last_recently_used_counter
+        self._last_recently_used_counter += 1
+        return tmp;

--- a/cache/FullAssociativeCache.py
+++ b/cache/FullAssociativeCache.py
@@ -25,7 +25,7 @@ class FullAssociativeCache(Cache):
                     current_address_int = int(word, 2)
                     if address_int == current_address_int:
                         # Update that block last time used parameter
-                        item = self._cache_block(datetime.now().microsecond, item.tag, *words)
+                        item = self._cache_block(self._generateRecentlyUsedCode(), item.tag, *words)
                         return True
             else:
                 # If found an empty block then break no need to complete searching in empty blocks
@@ -45,7 +45,7 @@ class FullAssociativeCache(Cache):
                 if item.lastUsedTime < min_last_time_used:
                     cache_index_to_add = i
                     min_last_time_used = item.lastUsedTime
-        self._cache[cache_index_to_add] = self._cache_block(datetime.now().microsecond,
+        self._cache[cache_index_to_add] = self._cache_block(self._generateRecentlyUsedCode(),
                                                             tag,
                                                             *words)
 

--- a/cache/SetAssociativeCache.py
+++ b/cache/SetAssociativeCache.py
@@ -14,6 +14,8 @@ class SetAssociativeCache(Cache):
         del self._cache
         # add a variables caches to hold an array of caches equal to number of sets
         self._caches = [[None] * number_of_blocks]
+        
+
         for i in range(numberOfSets -1):
             self._caches.append([None] * number_of_blocks)
 
@@ -39,7 +41,7 @@ class SetAssociativeCache(Cache):
                 word_at_index_int = int(words[word_index], 2)
                 if address_int == word_at_index_int:
                     # Update that block last time used parameter
-                    cache[index] = self._cache_block(datetime.now().microsecond, cache[index].tag, *words)
+                    cache[index] = self._cache_block(self._generateRecentlyUsedCode(), cache[index].tag, *words)
                     return True
         return False
 
@@ -55,7 +57,7 @@ class SetAssociativeCache(Cache):
                 if cache[index].lastUsedTime < min_last_time_used:
                     cache_index_to_add = i
                     min_last_time_used = cache[index].lastUsedTime
-        self._caches[cache_index_to_add][index] = self._cache_block(datetime.now().microsecond,
+        self._caches[cache_index_to_add][index] = self._cache_block(self._generateRecentlyUsedCode(),
                                                    tag,
                                                    *words)
     def getCacheTable(self):

--- a/problem_b.py
+++ b/problem_b.py
@@ -3,13 +3,13 @@ from problem_a import hexByteAddresses
 from cache.DirectMappingCache import DirectMappingCache
 
 
-def problem_b(cache):
+def problem_b(cache, allow_print):
 
     for hexAddress in hexByteAddresses:
-        cache.cache(hexAddress)
+        cache.cache(hexAddress, allow_print)
 
 if __name__ == '__main__':
     cache = DirectMappingCache(16, 1, 16)
-    problem_b(cache)
+    problem_b(cache, True)
     print cache.getCacheTable()
     print 'miss(e): %f'% (cache.getMissRate() * 100), '%'

--- a/problem_c.py
+++ b/problem_c.py
@@ -3,13 +3,13 @@ from problem_a import hexByteAddresses
 from cache.DirectMappingCache import DirectMappingCache
 
 
-def problem_c(cache):
+def problem_c(cache, allow_print):
 
     for hexAddress in hexByteAddresses:
-        cache.cache(hexAddress)
+        cache.cache(hexAddress, allow_print)
 
 if __name__ == '__main__':
     cache = DirectMappingCache(8, 2, 16)
-    problem_c(cache)
+    problem_c(cache, True)
     print cache.getCacheTable()
     print 'miss(e): %f'% (cache.getMissRate() * 100), '%'

--- a/problem_d.py
+++ b/problem_d.py
@@ -3,13 +3,13 @@ from problem_a import hexByteAddresses
 from cache.SetAssociativeCache import SetAssociativeCache
 
 
-def problem_d(cache):
+def problem_d(cache, allow_print):
 
     for index, hexAddress in enumerate(hexByteAddresses):
-        cache.cache(hexAddress)
+        cache.cache(hexAddress, allow_print)
 
 if __name__ == '__main__':
     cache = SetAssociativeCache(2, 4, 2, 16)
-    problem_d(cache)
+    problem_d(cache, True)
     print cache.getCacheTable()
     print 'miss(e): %f'% (cache.getMissRate() * 100), '%'

--- a/problem_e.py
+++ b/problem_e.py
@@ -3,13 +3,13 @@ from problem_a import hexByteAddresses
 from cache.FullAssociativeCache import FullAssociativeCache
 
 
-def problem_e(cache):
+def problem_e(cache, allow_print):
 
     for hexAddress in hexByteAddresses:
-        cache.cache(hexAddress)
+        cache.cache(hexAddress, allow_print)
 
 if __name__ == '__main__':
     cache = FullAssociativeCache(16, 1, 16)
-    problem_e(cache)
+    problem_e(cache, True)
     print cache.getCacheTable()
     print 'miss(e): %f'% (cache.getMissRate() * 100), '%'

--- a/problem_f.py
+++ b/problem_f.py
@@ -8,30 +8,58 @@ from cache.DirectMappingCache import DirectMappingCache
 from cache.SetAssociativeCache import SetAssociativeCache
 from cache.FullAssociativeCache import FullAssociativeCache
 
+# printing purposes
+allow_print = False
+
 #Problem B
+print("\n\n############ Part B ############\n")
 cache = DirectMappingCache(16, 1, 16)
 for i in range(100):
-    problem_b(cache)
+    if(i < 2):
+        allow_print = True
+        print "\nLoop %s" %(i,)
+    else:
+        allow_print = False
+
+    problem_b(cache, allow_print)
 print cache.getCacheTable()
 print 'miss(b): %f'% (cache.getMissRate() * 100), '%'
 
 #Problem C
+print("\n\n############ Part C ############\n")
 cache = DirectMappingCache(8, 2, 16)
 for i in range(100):
-    problem_c(cache)
+    if(i < 2):
+        allow_print = True
+        print "\nLoop %s" %(i,)
+    else:
+        allow_print = False
+    problem_c(cache, allow_print)
 print cache.getCacheTable()
 print 'miss(c): %f'% (cache.getMissRate() * 100), '%'
 
 #Problem D
+print("\n\n############ Part D ############\n")
 cache = SetAssociativeCache(2, 4, 2, 16)
 for i in range(100):
-    problem_d(cache)
+    if(i < 2):
+        allow_print = True
+        print "\nLoop %s" %(i,)
+    else:
+        allow_print = False
+    problem_d(cache, allow_print)
 print cache.getCacheTable()
 print 'miss(d): %f'% (cache.getMissRate() * 100), '%'
 
 #Problem E
+print("\n\n############ Part E ############\n")
 cache = FullAssociativeCache(16, 1, 16)
 for i in range(100):
-    problem_e(cache)
+    if(i < 2):
+        allow_print = True
+        print "\nLoop %s" %(i,)
+    else:
+        allow_print = False
+    problem_e(cache, allow_print)
 print cache.getCacheTable()
 print 'miss(e): %f'% (cache.getMissRate() * 100), '%'


### PR DESCRIPTION
There was a problem that microseconds does not have enough resolution to capture the fast code execution so sometimes several cache entries have the same recently used time, which leads to different and incorrect answers. The fix was to add a recently used counter, and whenever one cache entry is used increment that counter and make this new value the recently used code (time) of the cache entry.
